### PR TITLE
feat(): Infinite scrolling implemented, 10 stories at time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "14.2.4",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-intersection-observer": "^9.10.3"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -3791,6 +3792,20 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.10.3",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.10.3.tgz",
+      "integrity": "sha512-9NYfKwPZRovB6QJee7fDg0zz/SyYrqXtn5xTZU0vwLtLVBtfu9aZt1pVmr825REE49VPDZ7Lm5SNHjJBOTZHpA==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -9,18 +9,19 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18",
-    "next": "14.2.4"
+    "react-intersection-observer": "^9.10.3"
   },
   "devDependencies": {
-    "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "eslint": "^8",
+    "eslint-config-next": "14.2.4",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "eslint": "^8",
-    "eslint-config-next": "14.2.4"
+    "typescript": "^5"
   }
 }

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,9 @@
+const Loading = () => {
+  return (
+      <div className='container'>
+        <h2>Loading... <span style={{color:"green"}}>/o/</span></h2>
+      </div>
+  )
+}
+
+export default Loading

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,14 @@
-import { getTopStories } from "@/services/hn";
-import Link from "next/link";
+'use server';
+
+import { getPaginatedStories } from "@/services/hn";
+import StoryList from "@/components/StoryList";
+const LIMIT = 10;
 
 export default async function Home() {
-  const topstories = await getTopStories();
-
+  const topstories = await getPaginatedStories(0 ,LIMIT);
   return (
     <main>
-      { topstories.map((story, index) => {
-        const url = story.url ? new URL(story.url) : null;
-
-        return (
-          <div className="leading-none mb-4" key={story.id}>
-            <a title={story.title} href={story.url || `/${story.id}`} target={url?.host ? "_blank" : ""} className="pb-1 whitespace-nowrap text-ellipsis overflow-hidden block font-bold visited:text-slate-500">{index+1}. {story.title}</a>
-            <div className="text-xs text-slate-700">{url?.host ? `${url?.host} - ` : ''} <Link href={`/${story.id}`}>{story.score} poäng - {story.descendants || 'Inga'} kommentarer - {Math.floor(Date.now()/1000 - story.time)} sekunder sedan</Link></div>
-          </div>
-        )
-      }) }
+      <StoryList initialStories={topstories}/>
     </main>
   );
 }

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -1,0 +1,29 @@
+import { Story } from "@/types";
+import Link from "next/link";
+
+
+type StoryProps = {
+    story: Story;
+}
+
+export default function StoryCard({story}: StoryProps) {
+    const url = story.url ? new URL(story.url) : null;
+    return (
+        <div className="leading-none mb-4">
+        <a
+            title={story.title}
+            href={story.url || `/${story.id}`}
+            target={url?.host ? "_blank" : ""}
+            className="pb-1 whitespace-nowrap text-ellipsis overflow-hidden block font-bold visited:text-slate-500"
+        >
+            #{story.id}. {story.title}
+        </a>
+        <div className="text-xs text-slate-700">
+            {url?.host ? `${url.host} - ` : ''}
+            <Link href={`/${story.id}`}>
+                {story.score} poäng - {story.descendants || 'Inga'} kommentarer - {Math.floor((Date.now() / 1000) - story.time)} sekunder sedan
+            </Link>
+        </div>
+    </div>
+    )
+}

--- a/src/components/StoryList.tsx
+++ b/src/components/StoryList.tsx
@@ -1,0 +1,54 @@
+'use client';
+import StoryCard from "./StoryCard"
+import { Story } from "@/types"
+import { useEffect, useState } from "react";
+import { getPaginatedStories } from "@/services/hn";
+import { useInView } from "react-intersection-observer";
+import Loading from "@/app/loading";
+
+type StoryListProps = {
+  initialStories: Story[]
+}
+
+const LIMIT = 10;
+
+export default function StoryList({ initialStories }: StoryListProps) {
+  const [offset, setOffset] = useState(LIMIT);
+  const [stories, setStories] = useState<Story[]>(initialStories);
+  const [message, setMessage] = useState<string>();
+  const { ref, inView } = useInView({
+    threshold: 1, 
+  });
+
+  const loadMoreStories = async () => {
+    try {
+      const newStories = await getPaginatedStories(offset, LIMIT);
+      if (newStories.length === 0) {
+        setMessage("There is no more stories to load")
+        return; 
+      }
+      setStories([...stories, ...newStories]);
+      setOffset(prevOffset => prevOffset + LIMIT);
+    } catch (error) {
+      console.error('Error loading more stories:', error);
+    }
+  };
+
+  useEffect(() => {
+    if (inView) {
+      loadMoreStories();
+    }
+  }, [inView]);
+
+  return (
+    <div className='flex flex-col gap-3'>
+      {stories.map((story) => (
+        <StoryCard key={story.id} story={story} />
+      ))}
+      <div ref={ref} style={{ minHeight: '10px' }}>
+        {inView && !message && <Loading/>}
+      </div>
+      <p>{message && message}</p>
+    </div>
+  );
+}

--- a/src/services/hn.ts
+++ b/src/services/hn.ts
@@ -1,18 +1,16 @@
 import { Comment, Story } from "@/types";
+export const getPaginatedStories = async (offset: number, limit: number): Promise<Story[]> => {
+    const topStoriesIds: number[] = await fetch("https://hacker-news.firebaseio.com/v0/topstories.json")
+      .then(res => res.json());
 
-export const getTopStories = async ():Promise<Story[]> => {
-  const topstories:number[] = await fetch("https://hacker-news.firebaseio.com/v0/topstories.json", {
-    next: {
-      revalidate: 120
-    }
-  }).then(res => res.json());
-  
-  return Promise.all(topstories.splice(0, 10).map(id => fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json`, {
-    next: {
-      revalidate: 120
-    }
-  }).then(res => res.json())))
-}
+    const endIndex = offset + limit;
+    const storiesPromises = topStoriesIds.slice(offset, endIndex).map(id =>
+      fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json`)
+        .then(res => res.json())
+    );
+    
+    return await Promise.all(storiesPromises);
+};
 
 export const getStory = async (id:number):Promise<Story> => {
   return await fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json`, {


### PR DESCRIPTION
Change log
Task taken: 2. Implement Pagination or Infinite Scroll for Item List

Added infinite scroll, 10 stories at time is now displayed when we reach the targeted element "inView" and then it will also trigger the loading component while loading. I'm using the package "react-intersection-observer": "^9.10.3" for this to work so make sure you make a npm install before you try it out.
I managed to get a server-client error, but I didn't have more time to put into this task, as per your expectations regarding the required time. =)

Warning: Text content did not match. Server: "15342" Client: "15343"